### PR TITLE
Add callback to handle missing mesh node

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshStatusCallbacks.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshStatusCallbacks.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.mesh.transport.ControlMessage;
 import no.nordicsemi.android.mesh.transport.MeshMessage;
+import no.nordicsemi.android.mesh.transport.ProvisionedMeshNode;
 
 /**
  * Callbacks to notify the status of the mesh messages
@@ -44,6 +45,15 @@ public interface MeshStatusCallbacks {
      * @param hasIncompleteTimerExpired Flag that notifies if the incomplete timer had expired
      */
     void onTransactionFailed(final int dst, final boolean hasIncompleteTimerExpired);
+
+    /**
+     * Called when a message is received from a node that isn't in the database.
+     *
+     * @param addr  Address of the node
+     * @return A ProvisionedMeshNode (which must have been added to the MeshNetwork), or null if the
+     *         message should be discarded.
+     */
+    ProvisionedMeshNode onUnknownNode(final int addr);
 
     /**
      * Notifies if an unknown pdu was received

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/BaseMeshMessageHandler.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/BaseMeshMessageHandler.java
@@ -118,7 +118,12 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
                     Log.v(TAG, "TTL for received message: " + ttl);
                     final int src = MeshParserUtils.unsignedBytesToInt(networkHeader[5], networkHeader[4]);
 
-                    final ProvisionedMeshNode node = network.getNode(src);
+                    ProvisionedMeshNode node = network.getNode(src);
+
+                    if (node == null) {
+                        node = this.mStatusCallbacks.onUnknownNode(src);
+                    }
+
                     if (node == null) {
                         continue;
                     }


### PR DESCRIPTION
Allow the application to respond to messages which have been received from unknown nodes.

Submitted upstream as https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/pull/365