### PR TITLE
add a method for adding nodes to the network

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
@@ -931,6 +931,35 @@ abstract class BaseMeshNetwork {
     }
 
     /**
+     * Adds a mesh node to the list of provisioned nodes
+     *
+     * <p>
+     * Note that This method should only be used to add debug Nodes, or Nodes
+     * that have already been provisioned.
+     * </p>
+     *
+     * @param meshNode node to be added
+     * @return true if added and false otherwise
+     */
+    public boolean addNode(@NonNull final ProvisionedMeshNode meshNode) {
+        ProvisionedMeshNode sameAddressNode = getNode(meshNode.getUnicastAddress());
+        if (sameAddressNode != null) {
+            throw new IllegalStateException("cant add node with conflicting unicast address");
+        }
+
+        int index = 0;
+        for (ProvisionedMeshNode node : nodes) {
+            if (node.getUuid().equalsIgnoreCase(meshNode.getUuid())) {
+                nodes.set(index, meshNode); //replace a node if uuid matches
+                return true;
+            }
+            index++;
+        }
+
+        return nodes.add(meshNode);
+    }
+
+    /**
      * Deletes a mesh node from the list of provisioned nodes
      *
      * <p>


### PR DESCRIPTION
This adds a way for nodes to be added to the network aside from by provisioning them.

Submitted upstream as https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/pull/366