### PR TITLE
Correct get op code

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageAcked.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageAcked.java
@@ -34,8 +34,7 @@ public class VendorModelMessageAcked extends GenericMessage {
         super(appKey);
         this.mModelIdentifier = modelId;
         this.mCompanyIdentifier = companyIdentifier;
-        //Set the opCode to a 3-bit opCode
-        this.mOpCode = (0xC0 | opCode) << 16;
+        this.mOpCode = opCode;
         mParameters = parameters;
         assembleMessageParameters();
     }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageUnacked.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageUnacked.java
@@ -34,8 +34,7 @@ public class VendorModelMessageUnacked extends GenericMessage {
         super(appKey);
         this.mModelIdentifier = modelId;
         this.mCompanyIdentifier = companyIdentifier;
-        //Set the opCode to a 3-bit opCode
-        this.mOpCode = (0xC0 | mOpCode) << 16;
+        this.mOpCode = mOpCode;
         mParameters = parameters;
         assembleMessageParameters();
     }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/utils/MeshParserUtils.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/utils/MeshParserUtils.java
@@ -389,7 +389,8 @@ public class MeshParserUtils {
      * @return length of opcodes
      */
     public static byte[] createVendorOpCode(final int opCode, final int companyIdentifier) {
-        final byte[] opCodes = getOpCode(opCode);
+        final byte[] opCodes = new byte[3];
+        opCodes[0] = (byte) (opCode | 0xC0);
         opCodes[1] = (byte) (companyIdentifier & 0xFF);
         opCodes[2] = (byte) ((companyIdentifier >> 8) & 0xFF);
         return opCodes;

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/utils/MeshParserUtils.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/utils/MeshParserUtils.java
@@ -334,9 +334,9 @@ public class MeshParserUtils {
             case 2:
                 return MeshParserUtils.unsignedBytesToInt(accessPayload[1], accessPayload[0]);
             default:
-                return ((byte) (MeshParserUtils.unsignedByteToInt(accessPayload[1]))
-                        | (byte) ((MeshParserUtils.unsignedByteToInt(accessPayload[0]) << 8)
-                        | (byte) ((MeshParserUtils.unsignedByteToInt(accessPayload[2]) << 16))));
+                return ((MeshParserUtils.unsignedByteToInt(accessPayload[1]) << 8)
+                        + ((MeshParserUtils.unsignedByteToInt(accessPayload[0]) << 16)
+                        + ((MeshParserUtils.unsignedByteToInt(accessPayload[2]) << 0))));
         }
     }
 

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/utils/MeshParserUtilsTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/utils/MeshParserUtilsTest.java
@@ -8,9 +8,7 @@ import static org.junit.Assert.assertArrayEquals;
 
 public class MeshParserUtilsTest extends TestCase {
     public void testCreateVendorOpCode() {
-        // By observation, createVendorOpcode expects the opCode portion to already have been
-        // converted to a vendor op code by `or`ing with 0xC0 and shifting left by 16
-        byte[] payload = createVendorOpCode(0xC1 << 16, 0x05F1);
+        byte[] payload = createVendorOpCode(0x01, 0x05F1);
         byte[] expected = MeshParserUtils.toByteArray("C1F105");
 
         assertArrayEquals(expected, payload);

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/utils/MeshParserUtilsTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/utils/MeshParserUtilsTest.java
@@ -1,0 +1,26 @@
+package no.nordicsemi.android.mesh.utils;
+
+import junit.framework.TestCase;
+
+import static no.nordicsemi.android.mesh.utils.MeshParserUtils.createVendorOpCode;
+import static no.nordicsemi.android.mesh.utils.MeshParserUtils.getOpCode;
+import static org.junit.Assert.assertArrayEquals;
+
+public class MeshParserUtilsTest extends TestCase {
+    public void testCreateVendorOpCode() {
+        // By observation, createVendorOpcode expects the opCode portion to already have been
+        // converted to a vendor op code by `or`ing with 0xC0 and shifting left by 16
+        byte[] payload = createVendorOpCode(0xC1 << 16, 0x05F1);
+        byte[] expected = MeshParserUtils.toByteArray("C1F105");
+
+        assertArrayEquals(expected, payload);
+    }
+
+    public void testGetOpCode_vendorOpCode() {
+        byte[] payload = MeshParserUtils.toByteArray("C1F105");;
+
+        int calculatedOpCode = getOpCode(payload, 3);
+
+        assertEquals(0xC1F105, calculatedOpCode);
+    }
+}


### PR DESCRIPTION
Corrects the behaviour of `MeshParserUtils#getOpCode` with vendor op codes, and adds unit tests.

Also fixes `createVendorOpCode` to internally or with `0xC0` and shift, which fixes `AccessLayerTests#create_custom_access_message_isCorrect` and `create_custom_access_message_isCorrect1`.